### PR TITLE
Make og:image absolute urls for Twitter to behave.

### DIFF
--- a/source/layouts/article_layout.html.erb
+++ b/source/layouts/article_layout.html.erb
@@ -80,7 +80,7 @@
     <meta property="og:site_name" content="Sharesight">
     <meta property="og:title" content="<%= article_title&.gsub(/"/, "'") %> | Sharesight <% if page_info[:id] != 'usa'%><%=page_info[:country]%> Help<%else%>Help<%end%>">
     <meta property="og:description" content="<%= article_descr&.gsub(/"/, "'") %>">
-    <meta property="og:image" content="<%= image_path('sharesight-social-image@1200w.png') %>">
+    <meta property="og:image" content="<%= url_root %><%= image_path('sharesight-social-image@1200w.png') %>">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">

--- a/source/layouts/article_layout.html.erb
+++ b/source/layouts/article_layout.html.erb
@@ -80,12 +80,15 @@
     <meta property="og:site_name" content="Sharesight">
     <meta property="og:title" content="<%= article_title&.gsub(/"/, "'") %> | Sharesight <% if page_info[:id] != 'usa'%><%=page_info[:country]%> Help<%else%>Help<%end%>">
     <meta property="og:description" content="<%= article_descr&.gsub(/"/, "'") %>">
-    <meta property="og:image" content="<%= url_root %><%= image_path('sharesight-social-image@1200w.png') %>">
-    <meta property="og:image:type" content="image/png">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="630">
     <meta property="og:url" content="<%=url_root%><%=current_page.url%>">
     <meta property="og:type" content="website">
+
+    <meta property="og:image" content="<%= featured_img %>">
+    <% if featured_img.include?(image_path('sharesight-social-image@1200w.png')) %>
+      <meta property="og:image:type" content="image/png">
+      <meta property="og:image:width" content="1200">
+      <meta property="og:image:height" content="630">
+    <% end %>
 
     <meta name="twitter:site:id" content="109123696">
     <meta name="twitter:card" content="summary_large_image">

--- a/source/layouts/article_layout.html.erb
+++ b/source/layouts/article_layout.html.erb
@@ -7,8 +7,13 @@
   first_word_path = request.path.split('/').first
   tiny_locale = locale.gsub('en-', '').downcase
   page = page.present? ? page : ""
+
   article_title = page.present? ? "#{page.last.title.en} | Sharesight Help" : "Sharesight Help"
   article_descr = page.present? ? page.last.meta_description.en : "Articles and tutorial videos to help you get started with Sharesight, as well as to help troubleshoot common issues you may be experiencing."
+
+  featured_img   = page.present? && page&.last&.featured_img
+  featured_img ||= url_root + image_path('sharesight-social-image@1200w.png')
+  featured_img   = "https:#{featured_img}" if featured_img&.start_with?('//') # converts //images.contentful.com to https://images.contentful.com for Facebook to not complain.
 %>
     <% if first_word_path == 'index.html' || first_word_path.length > 2%>
   <html lang="en" class="no-js">

--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -73,7 +73,7 @@
     <meta property="og:site_name" content="Sharesight">
     <meta property="og:title" content="<%= page_info.first[:page_title]&.gsub(/"/, "'") %>">
     <meta property="og:description" content="<%= page_info.first[:page_description]&.gsub(/"/, "'") %>">
-    <meta property="og:image" content="<%= featured_img %>">
+    <meta property="og:image" content="<%= url_root %><%= featured_img %>">
     <% if featured_img == image_path('sharesight-social-image@1200w.png') %>
       <meta property="og:image:type" content="image/png">
       <meta property="og:image:width" content="1200">

--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -6,8 +6,10 @@
   include_blog_geo_redirect = locals[:include_blog_geo_redirect] || current_page.data.include_blog_geo_redirect
   first_word_path = request.path.split('/').first
   tiny_locale = locale.gsub('en-', '').downcase
-  page = page.present? ? page : ""
-  featured_img = page.present? ? page.last.featured_img : image_path('sharesight-social-image@1200w.png')
+
+  featured_img   = page.present? && page&.last&.featured_img
+  featured_img ||= url_root + image_path('sharesight-social-image@1200w.png')
+  featured_img   = "https:#{featured_img}" if featured_img&.start_with?('//') # converts //images.contentful.com to https://images.contentful.com for Facebook to not complain.
 %>
     <% if first_word_path == 'index.html' || first_word_path.length > 2%>
   <html lang="en" class="no-js">
@@ -73,14 +75,15 @@
     <meta property="og:site_name" content="Sharesight">
     <meta property="og:title" content="<%= page_info.first[:page_title]&.gsub(/"/, "'") %>">
     <meta property="og:description" content="<%= page_info.first[:page_description]&.gsub(/"/, "'") %>">
-    <meta property="og:image" content="<%= url_root %><%= featured_img %>">
-    <% if featured_img == image_path('sharesight-social-image@1200w.png') %>
+    <meta property="og:url" content="<%=url_root%><%= current_page.url %>">
+    <meta property="og:type" content="website">
+
+    <meta property="og:image" content="<%= featured_img %>">
+    <% if featured_img.include?(image_path('sharesight-social-image@1200w.png')) %>
       <meta property="og:image:type" content="image/png">
       <meta property="og:image:width" content="1200">
       <meta property="og:image:height" content="630">
     <% end %>
-    <meta property="og:url" content="<%=url_root%><%= current_page.url %>">
-    <meta property="og:type" content="website">
 
     <meta name="twitter:site:id" content="109123696">
     <meta name="twitter:card" content="summary_large_image">

--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -6,6 +6,7 @@
   include_blog_geo_redirect = locals[:include_blog_geo_redirect] || current_page.data.include_blog_geo_redirect
   first_word_path = request.path.split('/').first
   tiny_locale = locale.gsub('en-', '').downcase
+  page = page.present? ? page : ""
 
   featured_img   = page.present? && page&.last&.featured_img
   featured_img ||= url_root + image_path('sharesight-social-image@1200w.png')


### PR DESCRIPTION
Twitter does not go against the not-so-well-defined spec and does not error or work with relative urls.  Follow up to #7.