### PR TITLE
Bump Nokogiri to 1.10.3 for CVE-2019-11068.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,7 +323,7 @@ GEM
     minitest (5.10.1)
     multi_json (1.13.1)
     nenv (0.3.0)
-    nokogiri (1.8.5)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
CVE Issue:
https://github.com/sparklemotion/nokogiri/issues/1892