### PR TITLE
Bump `haml` for CVE-2017-1002201.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,8 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    haml (4.0.7)
+    haml (5.1.2)
+      temple (>= 0.8.0)
       tilt
     hike (1.2.3)
     hooks (0.4.1)
@@ -391,6 +392,7 @@ GEM
     stopwords-filter (0.4.1)
     string-urlize (1.0.2)
       i18n (~> 0.5)
+    temple (0.8.2)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (1.4.1)
@@ -439,4 +441,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.16.6
+   1.17.3


### PR DESCRIPTION
Could not create automated via [Github](https://github.com/sharesight/help.sharesight.com/network/alert/Gemfile.lock/haml), manually bumped instead.

[CVE Details on NIST](https://nvd.nist.gov/vuln/detail/CVE-2017-1002201)