### PR TITLE
ignore CVE-2020-8161 and CVE-2020-8165. 

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Ruby Security Audit
       run: |
         bundle exec bundle-audit update
-        bundle exec bundle-audit check --ignore CVE-2014-10077
+        bundle exec bundle-audit check --ignore CVE-2014-10077 CVE-2020-8161 CVE-2020-8165
 
 
     # -------- Slack Notification when Failed


### PR DESCRIPTION
neither affects our middleman use here, and both require a major middleman version update