### PR TITLE
Fix bundler to `v1.x` and fix `bundler-audit` gem naming.

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install Ruby Dependencies
       run: |
-        gem install bundler
+        gem install bundler -v "<2"
         bundle install --jobs 4 --retry 3
 
     - name: Ruby Security Audit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         ruby-version: '2.4.x'
     - name: Install Ruby Dependencies
       run: |
-        gem install bundler
+        gem install bundler -v "<2"
         bundle install --jobs 4 --retry 3
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,5 @@ group :test do
 end
 
 group :development, :test do
-  gem "bundle-audit"
+  gem "bundler-audit"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,8 +32,6 @@ GEM
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
     builder (3.2.2)
-    bundle-audit (0.1.0)
-      bundler-audit
     bundler-audit (0.6.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -415,7 +413,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-s3
-  bundle-audit
+  bundler-audit
   capybara
   capybara-selenium
   chromedriver-helper


### PR DESCRIPTION
Just re-implementing these two PRs as this suffers the same fate:
 - www.sharesight.com#220
 - www.sharesight.com#219