### PR TITLE
Update the Helpsite Footer: adds multiple links and Sharesight Pro.

### DIFF
--- a/source/css/_footer.scss
+++ b/source/css/_footer.scss
@@ -94,42 +94,31 @@ footer#footer {
   &__links {
     list-style: none;
     outline: none;
+    display: flex;
+    flex-wrap: wrap;
+    flex: 1 1 33%;
 
-    flex: 1 1 50%;
-
-    &--double-width {
+    // Mobile View:
+    @include respond-to(sm, max) {
+      align-items: flex-start;
       flex-basis: 100%;
-      display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
-      justify-content: flex-start;
-      align-items: start;
 
-      li {
-        flex-basis: 100%;
+      // Whitespace between link containers
+      & + & {
+        margin-top: $gutter/2;
       }
     }
 
-    @include respond-to(xs, min) {
-      &--double-width {
-        // Headers should only be 50% width, left-aligned.
-        li[role="none"] {
-          flex-basis: 50%;
-          margin-right: 50%;
+    & > li {
+      flex: 1 1 100%;
+
+      // Mobile View:
+      @include respond-to(sm, max) {
+        &.footer__link-header {
+          flex-basis: 100%;
         }
 
-        // Menu Items are 50% width and should be laid out in a grid below.
-        li[role="menuitem"] {
-          flex-basis: 50%;
-        }
-      }
-    }
-
-    @include respond-to(md, min) {
-      flex-basis: 25%;
-
-      &--double-width {
-        flex-basis: 40%; // NOTE: Not actually "double" here, just larger.
+        flex-basis: 50%;
       }
     }
   }
@@ -284,16 +273,25 @@ footer#footer {
     }
   }
 
+  &__link,
   &__link-header {
     @include fontSize(16px, 30px);
+    padding: 0;
+    color: #fff;
+  }
+
+  &__link-header {
     font-weight: 600;
     text-transform: lowercase;
     font-variant: small-caps;
+
+    @include respond-to(sm, max) {
+      @include fontSize(20px);
+    }
   }
 
   &__link {
-    @include fontSize(15px, 30px); // match link-header
-    color: white;
+    @include fontSize(15px); // same line-height, different size as link-header
     font-weight: 100;
   }
 

--- a/source/css/_footer.scss
+++ b/source/css/_footer.scss
@@ -114,11 +114,12 @@ footer#footer {
 
       // Mobile View:
       @include respond-to(sm, max) {
-        &.footer__link-header {
-          flex-basis: 100%;
-        }
-
         flex-basis: 50%;
+
+        &.footer__link-header {
+          // Make this align with the other navigation's left column.
+          margin-right: 50%;
+        }
       }
     }
   }

--- a/source/partials/_footer.html.erb
+++ b/source/partials/_footer.html.erb
@@ -9,36 +9,32 @@
     # label => items
     #   - item: { name, marketing_page, href, title }
     #   - hreftle can be auto-generated from a `marketing_page`
-    'Company' => [
+    'Sharesight' => [
       { name: 'www.sharesight.com', marketing_page: '', title: locale_obj[:append_title] },
-      { name: 'Executive Team', href: unlocalized_url('team', base_url: config[:marketing_url]), title: "Executive Team | Sharesight" }, # NOTE: Not a localized page!
       { name: 'About Us', marketing_page: 'about-sharesight', title: "About Us | #{locale_obj[:append_title]}" },
+      { name: 'Executive Team', href: unlocalized_url('team', base_url: config[:marketing_url]), title: "Executive Team | Sharesight" }, # NOTE: Not a localized page!
       { name: 'FAQ', marketing_page: 'faq', title: "Frequently Asked Questions | #{locale_obj[:append_title]}" },
       { name: 'Pricing', marketing_page: 'pricing', title: "Pricing | #{locale_obj[:append_title]}" },
-      { name: 'Webinars & Events', marketing_page: 'events', title: "Webinars & Events | #{locale_obj[:append_title]}" }
+      { name: 'Reviews', marketing_page: 'reviews', title: "Reviews | #{locale_obj[:append_title]}" },
     ],
 
     # This has an empty label—no header, but still space
-    '' => [
+    'Partners' => [
       { name: 'Sharesight Pro', marketing_page: 'pro', title: "Sharesight Pro" },
-      { name: 'Partners', marketing_page: 'partners', title: "Partners | #{locale_obj[:append_title]}" },
+      { name: 'Partner Directory', marketing_page: 'partners', title: "Partner Directory | #{locale_obj[:append_title]}" },
       { name: 'Become a Partner', marketing_page: 'become-a-partner', title: "Partner with Sharesight | #{locale_obj[:append_title]}" },
-      { name: 'Affiliates', marketing_page: 'affiliates', title: "Affiliates | #{locale_obj[:append_title]}" },
-      { name: 'Reviews', marketing_page: 'reviews', title: "Reviews | #{locale_obj[:append_title]}" }
+      { name: 'Become an Affiliate', marketing_page: 'affiliates', title: "Become an Affiliate | #{locale_obj[:append_title]}" },
+      { name: 'Sharesight API', href: config[:api_url], title: 'Sharesight API Documentation' },
+      { name: 'sales@sharesight.com', href: 'mailto:sales@sharesight.com', title: 'Email the Sales Team' },
     ],
 
     'Resources' => [
+      { name: 'Help Centre', href: localize_url(locale_id: locale_obj[:id]), title: "Help Centre | #{locale_obj[:append_title]}" },
       { name: 'Blog', href: unlocalized_url('blog', base_url: config[:marketing_url]), title: 'Sharesight Blog' },
-      { name: 'API Documentation', href: config[:api_url], title: 'Sharesight Developer API Documentation' },
+      { name: 'Webinars & Events', marketing_page: 'events', title: "Webinars & Events | #{locale_obj[:append_title]}" },
       { name: 'Privacy Policy', marketing_page: 'privacy-policy', title: "Privacy Policy | #{locale_obj[:append_title]}" },
       { name: 'Terms of Use', marketing_page: 'sharesight-terms-of-use', title: "Terms of Use | #{locale_obj[:append_title]}" },
-      { name: 'Pro Terms of Use', marketing_page: 'sharesight-professional-terms-of-use', title: "Terms of Service | Sharesight Pro" }
-    ],
-
-    'Support' => [
-      { name: 'Help', href: localize_url(locale_id: locale_obj[:id]), title: "Help | #{locale_obj[:append_title]}" },
-      { name: 'Community Forum', href: config[:community_url], title: 'Sharesight Community Forum' },
-      { name: 'sales@sharesight.com', href: 'mailto:sales@sharesight.com', title: 'Email the Sales Team' },
+      { name: 'Pro Terms of Use', marketing_page: 'sharesight-professional-terms-of-use', title: "Terms of Service | Sharesight Pro" },
     ]
   }
 %>

--- a/source/partials/_footer.html.erb
+++ b/source/partials/_footer.html.erb
@@ -1,7 +1,47 @@
-<% index_page_title = locale_page(page: 'index', locale_obj: locale_obj)[:page_title] %>
+<%
+  index_page_title = locale_page(page: 'index', locale_obj: locale_obj)[:page_title]
 
-<%# if hide_global_footer_cta is set to true (typically from a layout file), we don't show the notice %>
-<% hide_global_footer_cta = locals[:hide_global_footer_cta] || current_page.data.hide_global_footer_cta %>
+  # if hide_global_footer_cta is set to true (typically from a layout file), we don't show the notice
+  hide_global_footer_cta = locals[:hide_global_footer_cta] || current_page.data.hide_global_footer_cta
+
+  # NOTE: This should typically be 1:1 with the Marketing Site, just the urls and titles are different.
+  footer_columns_links = {
+    # label => items
+    #   - item: { name, marketing_page, href, title }
+    #   - hreftle can be auto-generated from a `marketing_page`
+    'Company' => [
+      { name: 'www.sharesight.com', marketing_page: '', title: locale_obj[:append_title] },
+      { name: 'Executive Team', href: unlocalized_url('team', base_url: config[:marketing_url]), title: "Executive Team | Sharesight" }, # NOTE: Not a localized page!
+      { name: 'About Us', marketing_page: 'about-sharesight', title: "About Us | #{locale_obj[:append_title]}" },
+      { name: 'FAQ', marketing_page: 'faq', title: "Frequently Asked Questions | #{locale_obj[:append_title]}" },
+      { name: 'Pricing', marketing_page: 'pricing', title: "Pricing | #{locale_obj[:append_title]}" },
+      { name: 'Webinars & Events', marketing_page: 'events', title: "Webinars & Events | #{locale_obj[:append_title]}" }
+    ],
+
+    # This has an empty label—no header, but still space
+    '' => [
+      { name: 'Sharesight Pro', marketing_page: 'pro', title: "Sharesight Pro" },
+      { name: 'Partners', marketing_page: 'partners', title: "Partners | #{locale_obj[:append_title]}" },
+      { name: 'Become a Partner', marketing_page: 'become-a-partner', title: "Partner with Sharesight | #{locale_obj[:append_title]}" },
+      { name: 'Affiliates', marketing_page: 'affiliates', title: "Affiliates | #{locale_obj[:append_title]}" },
+      { name: 'Reviews', marketing_page: 'reviews', title: "Reviews | #{locale_obj[:append_title]}" }
+    ],
+
+    'Resources' => [
+      { name: 'Blog', href: unlocalized_url('blog', base_url: config[:marketing_url]), title: 'Sharesight Blog' },
+      { name: 'API Documentation', href: config[:api_url], title: 'Sharesight Developer API Documentation' },
+      { name: 'Privacy Policy', marketing_page: 'privacy-policy', title: "Privacy Policy | #{locale_obj[:append_title]}" },
+      { name: 'Terms of Use', marketing_page: 'sharesight-terms-of-use', title: "Terms of Use | #{locale_obj[:append_title]}" },
+      { name: 'Pro Terms of Use', marketing_page: 'sharesight-professional-terms-of-use', title: "Terms of Service | Sharesight Pro" }
+    ],
+
+    'Support' => [
+      { name: 'Help', href: localize_url(locale_id: locale_obj[:id]), title: "Help | #{locale_obj[:append_title]}" },
+      { name: 'Community Forum', href: config[:community_url], title: 'Sharesight Community Forum' },
+      { name: 'sales@sharesight.com', href: 'mailto:sales@sharesight.com', title: 'Email the Sales Team' },
+    ]
+  }
+%>
 
 <% if !hide_global_footer_cta %>
   <div class="section notice">
@@ -57,105 +97,25 @@
       </div>
     </div>
 
-    <div class="footer__links_container">
-      <ul class="footer__links footer__links--double-width" id="main-menu" role="menubar" aria-label="Company Links">
-        <li role="none" class="footer__link-header">Company</li>
-        <li role="menuitem">
-          <a href="<%= localize_url(locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Sharesight">
-            www.sharesight.com
-          </a>
-        </li>
+    <div class="footer__links_container" id="main-menu">
+      <% footer_columns_links.each do |label, items| %>
 
-        <li role="menuitem">
-          <a href="<%= localize_url('faq', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Frequently Asked Questions | Sharesight">
-            FAQ
-          </a>
-        </li>
+        <ul class="footer__links footer__links" role="menubar" aria-label="<%= label ? "#{label} Links" : "" %>">
+          <li role="none" class="footer__link-header"><%= label %>&#8203;</li><!-- NOTE: `&#8203;` here is a special space that ensures it always takes up the line-height -->
 
-        <li role="menuitem">
-          <a href="<%= localize_url('about-sharesight', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="About Us | Sharesight">
-            About Us
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= unlocalized_url('blog', base_url: config[:marketing_url]) %>" class="footer__link" title="Sharesight Blog">
-            Blog
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('pricing', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Pricing | Sharesight">
-            Pricing
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('partners', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Partners | Sharesight">
-            Partners
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('reviews', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Reviews | Sharesight">
-            Reviews
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('become-a-partner', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Become a Partner | Sharesight">
-            Become a Partner
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('affiliates', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Affiliates | Sharesight">
-            Affiliates
-          </a>
-        </li>
-      </ul>
-
-      <ul class="footer__links" id="main-menu" role="menubar" aria-label="Resources Links">
-        <li role="none" class="footer__link-header">Resources</li>
-        <li role="menuitem">
-          <a href="<%= config[:api_url] %>" class="footer__link" title="Sharesight Developer API">
-            Developer API
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('privacy-policy', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Privacy Policy | Sharesight">
-            Privacy Policy
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('sharesight-terms-of-use', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Terms of Service | Sharesight">
-            Terms of Use
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= localize_url('sharesight-professional-terms-of-use', locale_id: locale_obj[:id], base_url: config[:marketing_url]) %>" class="footer__link" title="Terms of Service | Sharesight Pro">
-            Pro Terms of Use
-          </a>
-        </li>
-      </ul>
-
-      <ul class="footer__links" id="main-menu" role="menubar" aria-label="Support Links">
-        <li role="none" class="footer__link-header">Support</li>
-        <li role="menuitem">
-          <a href="<%= localize_url(locale_id: locale_obj[:id]) %>" class="footer__link" title="<%= locale_obj[:default_title] %>">
-            Help Centre
-          </a>
-        </li>
-
-        <li role="menuitem">
-          <a href="<%= config[:community_url] %>" class="footer__link" title="Sharesight Community Forum">
-            Community Forum
-          </a>
-        </li>
-      </ul>
+          <%
+            items.each do |item|
+              href = item[:href]
+              href ||= localize_url(item[:marketing_page], locale_id: locale_obj[:id], base_url: config[:marketing_url])
+          %>
+            <li role="menuitem">
+              <a href="<%= href %>" class="footer__link" title="<%= item[:title] %>">
+                <%= item[:name] %>
+              </a>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
     </div>
 
     <ul class="footer__regional-links" role="menubar" aria-label="Regional Website Links">

--- a/spec/features/footer_spec.rb
+++ b/spec/features/footer_spec.rb
@@ -8,32 +8,29 @@ describe 'Footer', type: :feature do
     expected_links = [
       # text, href
 
-      # Company:
+      # Sharesight:
       ["www.sharesight.com", Capybara.app.config[:marketing_url]],
-      ["Executive Team", base_url("/team/", base_url: Capybara.app.config[:marketing_url])],
       ["About Us", base_url("/about-sharesight/", base_url: Capybara.app.config[:marketing_url])],
+      ["Executive Team", base_url("/team/", base_url: Capybara.app.config[:marketing_url])],
       ["FAQ", base_url("/faq/", base_url: Capybara.app.config[:marketing_url])],
       ["Pricing", base_url("/pricing/", base_url: Capybara.app.config[:marketing_url])],
-      ["Webinars & Events", base_url("/events/", base_url: Capybara.app.config[:marketing_url])],
-
-      # Company pt2:
-      ["Sharesight Pro", base_url("/pro/", base_url: Capybara.app.config[:marketing_url])],
-      ["Become a Partner", base_url("/become-a-partner/", base_url: Capybara.app.config[:marketing_url])],
-      ["Partners", base_url("/partners/", base_url: Capybara.app.config[:marketing_url])],
-      ["Affiliates", base_url("/affiliates/", base_url: Capybara.app.config[:marketing_url])],
       ["Reviews", base_url("/reviews/", base_url: Capybara.app.config[:marketing_url])],
 
+      # Partners:
+      ["Sharesight Pro", base_url("/pro/", base_url: Capybara.app.config[:marketing_url])],
+      ["Partner Directory", base_url("/partners/", base_url: Capybara.app.config[:marketing_url])],
+      ["Become a Partner", base_url("/become-a-partner/", base_url: Capybara.app.config[:marketing_url])],
+      ["Become an Affiliate", base_url("/affiliates/", base_url: Capybara.app.config[:marketing_url])],
+      ["Sharesight API", Capybara.app.config[:api_url]],
+      ["sales@sharesight.com", 'mailto:sales@sharesight.com'],
+
       # Resources:
+      ["Help Centre", Capybara.app.config[:help_url]],
       ["Blog", base_url("/blog/", base_url: Capybara.app.config[:marketing_url])],
-      ["API Documentation", Capybara.app.config[:api_url]],
+      ["Webinars & Events", base_url("/events/", base_url: Capybara.app.config[:marketing_url])],
       ["Privacy Policy", base_url("/privacy-policy/", base_url: Capybara.app.config[:marketing_url])],
       ["Terms of Use", base_url("/sharesight-terms-of-use/", base_url: Capybara.app.config[:marketing_url])],
       ["Pro Terms of Use", base_url("/sharesight-professional-terms-of-use/", base_url: Capybara.app.config[:marketing_url])],
-
-      # Support:
-      ["Help", Capybara.app.config[:help_url]],
-      ["Community Forum", Capybara.app.config[:community_url]],
-      ["sales@sharesight.com", 'mailto:sales@sharesight.com'],
 
       # locales:
       ["Global", base_url('/')],

--- a/spec/features/footer_spec.rb
+++ b/spec/features/footer_spec.rb
@@ -1,24 +1,67 @@
 require 'spec_helper'
 
 describe 'Footer', type: :feature do
-  it 'should have the correct links' do
-    [
-      /^www.sharesight.com/,
-      /^About Us/,
-      /^Pricing/,
-      /^Reviews/,
-      /^Affiliates/,
-      /^Become a Partner/,
-      /^FAQ/,
-      /^Blog/,
-      /^Partners/,
-      /^Developer API/,
-      /^Privacy Policy/,
-      /^Terms of Use/,
-      /^Pro Terms of Use/,
-    ].each do |text|
-      visit '/'
-      expect(page.find('a.footer__link', text: text)).to_not be_nil
+  it 'should have all expected links' do
+    visit '/'
+    links = page.all(:css, 'a.footer__link')
+
+    expected_links = [
+      # text, href
+
+      # Company:
+      ["www.sharesight.com", Capybara.app.config[:marketing_url]],
+      ["Executive Team", base_url("/team/", base_url: Capybara.app.config[:marketing_url])],
+      ["About Us", base_url("/about-sharesight/", base_url: Capybara.app.config[:marketing_url])],
+      ["FAQ", base_url("/faq/", base_url: Capybara.app.config[:marketing_url])],
+      ["Pricing", base_url("/pricing/", base_url: Capybara.app.config[:marketing_url])],
+      ["Webinars & Events", base_url("/events/", base_url: Capybara.app.config[:marketing_url])],
+
+      # Company pt2:
+      ["Sharesight Pro", base_url("/pro/", base_url: Capybara.app.config[:marketing_url])],
+      ["Become a Partner", base_url("/become-a-partner/", base_url: Capybara.app.config[:marketing_url])],
+      ["Partners", base_url("/partners/", base_url: Capybara.app.config[:marketing_url])],
+      ["Affiliates", base_url("/affiliates/", base_url: Capybara.app.config[:marketing_url])],
+      ["Reviews", base_url("/reviews/", base_url: Capybara.app.config[:marketing_url])],
+
+      # Resources:
+      ["Blog", base_url("/blog/", base_url: Capybara.app.config[:marketing_url])],
+      ["API Documentation", Capybara.app.config[:api_url]],
+      ["Privacy Policy", base_url("/privacy-policy/", base_url: Capybara.app.config[:marketing_url])],
+      ["Terms of Use", base_url("/sharesight-terms-of-use/", base_url: Capybara.app.config[:marketing_url])],
+      ["Pro Terms of Use", base_url("/sharesight-professional-terms-of-use/", base_url: Capybara.app.config[:marketing_url])],
+
+      # Support:
+      ["Help", Capybara.app.config[:help_url]],
+      ["Community Forum", Capybara.app.config[:community_url]],
+      ["sales@sharesight.com", 'mailto:sales@sharesight.com'],
+
+      # locales:
+      ["Global", base_url('/')],
+      ["Australia", base_url('/au/')],
+      ["Canada", base_url('/ca/')],
+      ["New Zealand", base_url('/nz/')],
+      ["United Kingdom", base_url('/uk/')],
+    ]
+
+    expect(links.length).to eq(expected_links.length)
+
+    # iterate through all links on the page and find
+    links.each do |link|
+      matched_link = expected_links.find do |expected_link|
+        link.text.match(expected_link[0])
+      end
+
+      expect(matched_link).to_not(be_nil, "Unexpected link '#{link.text}'!")
+
+      expected_href = matched_link[1]
+      if expected_href
+        expect(link[:href]).to(match(expected_href), "Link '#{link.text}' did not match expected href of '#{expected_href}'.  Received '#{link[:href]}' instead.")
+      end
+
+      expected_links.delete(matched_link)
     end
+
+
+    expect(expected_links.length).to(eq(0), "Found leftover links in expected_links: #{expected_links}")
   end
 end


### PR DESCRIPTION
Taking from https://github.com/sharesight/www.sharesight.com/pull/236

We were missing several links, this just brings this 1:1 with the helpsite.

**TODO:**
 - [x] Implement some feedback.
 - [x] Pass https://github.com/sharesight/www.sharesight.com/pull/236