### PR TITLE
Remove unused gem, `redcarpet`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'middleman-syntax'
 # support re-writing in the middleman configuration
 gem 'rack-rewrite'
 gem 'string-urlize'
-gem 'redcarpet'
 gem 'aws-s3'
 gem 'middleman-remover'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,6 @@ GEM
       json (>= 1.8)
       nokogiri (~> 1.5)
       trollop (~> 2.1)
-    redcarpet (3.3.4)
     rouge (2.0.6)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -435,7 +434,6 @@ DEPENDENCIES
   rack-rewrite
   rails-html-sanitizer (~> 1.0.4)
   rake
-  redcarpet
   rspec
   stopwords-filter
   string-urlize


### PR DESCRIPTION
This package currently has open Security Vulnerability around it and is updated in #76.  Ideally, this supersedes as it may be the better course of action.

This appears to be unused.  We do not use it in https://github.com/sharesight/www.sharesight.com and it appears to not be called in our codebase.

 - [x] It passes CI.