### PR TITLE
Specify [latest] versions for `checkout` and `slatify` actions.

### DIFF
--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     # -------- Github Checkout
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
 
     # -------- Ruby & Dependencies
@@ -40,7 +40,7 @@ jobs:
 
     # -------- Slack Notification when Failed
     - name: Send Failure Notification
-      uses: homoluctus/slatify@master
+      uses: lazy-actions/slatify@3.0.0
       if: failure()
       with:
         type: ${{ job.status }}

--- a/.github/workflows/bundle-audit.yml
+++ b/.github/workflows/bundle-audit.yml
@@ -40,7 +40,7 @@ jobs:
 
     # -------- Slack Notification when Failed
     - name: Send Failure Notification
-      uses: lazy-actions/slatify@3.0.0
+      uses: lazy-actions/slatify@v3.0.0
       if: failure()
       with:
         type: ${{ job.status }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
 
     # -------- Github Checkout
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
 
     # -------- Ruby & Dependencies
@@ -127,7 +127,7 @@ jobs:
 
     # -------- Slack Notifications (different for test vs. deploy).
     - name: Send Deploy Notification
-      uses: homoluctus/slatify@v1.8.0
+      uses: lazy-actions/slatify@v3.0.0
       if: steps.env.outputs.should_deploy == 'true' && always()
       with:
         type: ${{ job.status }}
@@ -136,7 +136,7 @@ jobs:
         icon_emoji: ':rocket:'
         url: ${{ secrets.SLACK_WEBHOOK_URL }}
     - name: Send Test Failed Notification
-      uses: homoluctus/slatify@v1.8.0
+      uses: lazy-actions/slatify@v3.0.0
       if: steps.env.outputs.should_deploy == 'false' && failure()
       with:
         type: ${{ job.status }}


### PR DESCRIPTION
I noticed a failure on `slatify@v1.8.0` that I couldn't explain (https://github.com/sharesight/help.sharesight.com/runs/2077917171?check_suite_focus=true) and I noticed our versions were mis-matched (master vs. 1.8).  Figured I should make all versions consistent.

In another PR, I've set Dependabot to auto-update these Github Actions.