### PR TITLE
Filter the `Miscellaneous` category from being visible.

### DIFF
--- a/helpers/middleman/collection.rb
+++ b/helpers/middleman/collection.rb
@@ -60,7 +60,7 @@ module MiddlemanCollectionHelpers
       .map{ |tuple| tuple[1] }
       .map{ |category| localize_entry(category, lang, default_locale_obj[:lang]) }
       .select{ |category| is_valid_category_model?(category) }
-      .select{ |category| !(category[:id] === '5OiSIUarvyOi84yWQwE4S' || category[:name] === 'Miscellaneous') } # Filter out the "Miscellaneous" category:
+      .reject{ |category| category[:name] === 'Miscellaneous' } # Filter out the "Miscellaneous" category:
 
     # add associated pages, with children
     if with_associations

--- a/helpers/middleman/collection.rb
+++ b/helpers/middleman/collection.rb
@@ -58,8 +58,9 @@ module MiddlemanCollectionHelpers
 
     collection = data.help.categories
       .map{ |tuple| tuple[1] }
-      .map{ |model| localize_entry(model, lang, default_locale_obj[:lang]) }
-      .select{ |model| is_valid_category_model?(model) }
+      .map{ |category| localize_entry(category, lang, default_locale_obj[:lang]) }
+      .select{ |category| is_valid_category_model?(category) }
+      .select{ |category| !(category[:id] === '5OiSIUarvyOi84yWQwE4S' || category[:name] === 'Miscellaneous') } # Filter out the "Miscellaneous" category:
 
     # add associated pages, with children
     if with_associations

--- a/spec/features/help_pages_page_spec.rb
+++ b/spec/features/help_pages_page_spec.rb
@@ -77,13 +77,17 @@ describe 'Help Pages', :type => :feature do
 
     pages_in_this_locale = get_pages(locale)
 
-    pages_in_this_locale.each do |_page|
+    pages_in_this_locale.select do |_page| 
       # if the page has multiple parents, it doesn't show; navigation only goes one layer deep
-      has_multiple_parents = true if _page[:parent_page] && _page[:parent_page][:parent_page]
-      unless has_multiple_parents
-        page_url = Capybara.app.page_url(_page, locale_id: locale[:id])
-        expect(page).to have_css("a[href='#{page_url}']", text: _page[:title].strip, visible: false) # visible or not
-      end
+      return false if _page[:parent_page] && _page[:parent_page][:parent_page]
+
+      # We hide this category…
+      return false if _page[:category][:name] === 'Miscellaneous'
+
+      return true
+    end.each do |_page|
+      page_url = Capybara.app.page_url(_page, locale_id: locale[:id])
+      expect(page).to have_css("a[href='#{page_url}']", text: _page[:title].strip, visible: false) # visible or not
     end
   end
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -30,6 +30,11 @@ describe 'Index Page', :type => :feature do
     end
   end
 
+  it "should not have a Miscellaneous help topic" do
+    visit '/'
+    expect(page).not_to have_css("a", text: "Miscellaneous")
+  end
+
   it "should have a community and videos section" do
     locales.each do |locale|
       visit locale.path

--- a/spec/helpers/middleman/collection_spec.rb
+++ b/spec/helpers/middleman/collection_spec.rb
@@ -56,6 +56,18 @@ describe 'Collection Middleman Helper', :type => :helper do
       end
     end
 
+    it "filters out the Miscellaneous category" do
+      # Does exist in the raw data…
+      raw_categories = @app.data.help.categories.map{ |tuple| tuple[1] }.map{ |c| c[:name][:en] }
+      expect(raw_categories).to include('Miscellaneous')
+
+      # Does not exist in the categories_collection
+      categories = @app.categories_collection().map{ |c| c[:name] }
+      expect(categories).not_to include('Miscellaneous')
+
+      expect(raw_categories.length).to be > categories.length
+    end
+
     it "should include pages when associations are requested" do
       data = @app.categories_collection(with_associations: true)
       expect(data).to be_kind_of(Array)

--- a/spec/support/helpers/collection.rb
+++ b/spec/support/helpers/collection.rb
@@ -35,7 +35,9 @@ module CapybaraCollectionHelpers
       category
     end
 
-    categories = categories.select{|category| Capybara.app.is_valid_category_model?(category)}
+    categories = categories
+      .select{|category| Capybara.app.is_valid_category_model?(category)}
+      .select{ |category| !(category[:id] === '5OiSIUarvyOi84yWQwE4S' || category[:name] === 'Miscellaneous') } # Filter out the "Miscellaneous" category:
 
     categories
   end

--- a/spec/support/helpers/collection.rb
+++ b/spec/support/helpers/collection.rb
@@ -37,7 +37,7 @@ module CapybaraCollectionHelpers
 
     categories = categories
       .select{|category| Capybara.app.is_valid_category_model?(category)}
-      .select{ |category| !(category[:id] === '5OiSIUarvyOi84yWQwE4S' || category[:name] === 'Miscellaneous') } # Filter out the "Miscellaneous" category:
+      .reject{ |category| category[:name] === 'Miscellaneous' } # Filter out the "Miscellaneous" category:
 
     categories
   end


### PR DESCRIPTION
Vimaly Story: https://vimaly.com/#j8mqm/t/help_Hide_the_Miscellaneous_category_from_IA./iVrDivkZXuXexNLWy

tl;dr: Customer Support have restructured the help site content and put duplicates or things that shouldn't live in the IA into a `Miscellaneous` category.  They want this `Miscellaneous` category hidden.

---

The complexity here was just finding the places it might fail tests, I think I described that well.