### PR TITLE
Bump to latest Nokogiri for CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
     minitest (5.10.1)
     multi_json (1.13.1)
     nenv (0.3.0)
-    nokogiri (1.13.3)
+    nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.1)


### PR DESCRIPTION
See sharesight/investapp#10207 for full investigation in our primary product.

Tracked on [Vimaly Ticket](https://vimaly.com/#j8mqm/t/Nokogiri_CVE/31Y5H8h7rxMm3HFF7)

CVEs:
 - CVE-2022-24839
 - CVE-2022-24836
 - CVE-2018-25032
 - CVE-2022-23437

Changelog: https://nokogiri.org/CHANGELOG.html#1134-2022-04-11