### PR TITLE
Update the `nokogiri` gem from 1.13.4 to 1.13.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
     minitest (5.10.1)
     multi_json (1.13.1)
     nenv (0.3.0)
-    nokogiri (1.13.3)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.1)


### PR DESCRIPTION
In order to handle security issues:
 - CVE-2022-29181
 - GHSA-xh29-r2w5-wx8m
 - GHSA-cgx6-hpwq-fhv5

According to their changelog those patches are only internal changes without any breaking changes.

---

⚠️ Unfortunately I cannot run `bundle` in this repo [on an M1] as the test suite installs an `ffi` gem version which does not natively compile.  I believe this is the correct bump, however; just done manually copied from https://github.com/sharesight/www.sharesight.com/pull/377.