### PR TITLE
Remove Bugsnag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       run: bundle exec rspec spec -p --format d
 
 
-    # -------- Deploy to S3 ++ Notify Bugsnag and Github Deployment of Status
+    # -------- Deploy to S3 and notify Github Deployment of Status
     - name: Update deployment status to pending
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
       uses: 'deliverybot/deployment-status@v1.1.1'
@@ -91,24 +91,11 @@ jobs:
       with:
         state: 'pending'
         token: ${{ secrets.GITHUB_TOKEN }}
+   
     - name: Deploy to S3
       if: success() && steps.env.outputs.should_deploy == 'true'
       run: bundle exec middleman s3_sync
-    - name: Notify Bugsnag of Released Code
-      if: success() && steps.env.outputs.should_deploy == 'true'
-      run: |
-        curl https://build.bugsnag.com/ \
-          --header "Content-Type: application/json" \
-          --data '{
-            "apiKey": ${{ secrets.BUGSNAG_API_KEY }},
-            "releaseStage": ${{ steps.env.outputs.app_env }},
-            "builderName": "Github Actions",
-            "sourceControl": {
-              "provider": "github",
-              "repository": ${{ github.repository }},
-              "revision": ${{ github.sha }}
-            }
-          }'
+
     - name: Update deployment status to success
       # NOTE: Only for deployment events, not commits/etc (which don't have an external deployment context)
       if:  github.event_name == 'deployment' && success() && steps.env.outputs.should_deploy == 'true'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ To run locally, something like `.envrc` is suggested.
 https://github.com/sharesight/help.sharesight.com/settings/secrets
  - AWS_DEPLOY_ACCESS_ID	- for deploying to AWS S3 on user help_deploy
  - AWS_DEPLOY_SECRET_KEY	- for deploying to AWS S3 on user help_deploy
- - BUGSNAG_API_KEY	– for posting releases to Bugsnag
  - CONTENTFUL_MASTER_TOKEN - for pulling published content from [Contentful]( https://app.contentful.com/spaces/kw7pc879iryd/api/keys)
  - CONTENTFUL_PREVIEW_TOKEN	- for pulling draft content from [Contentful]( https://app.contentful.com/spaces/kw7pc879iryd/api/keys)
  - SLACK_WEBHOOK_URL - for posting into Slack notifications/etc

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,10 +9,6 @@ module ApplicationConfig
     TAG_MANAGER_CONTAINER = 'GTM-5HSWD9'
   end
 
-  module Bugsnag
-    API_KEY = ENV['BUGSNAG_API_KEY']
-  end
-
   module Intercom
 		APP_ID = 'tv6jsyee'
 	end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -9,10 +9,6 @@ module ApplicationConfig
 		TAG_MANAGER_CONTAINER = 'GTM-P2DH5X'
 	end
 
-	module Bugsnag
-		API_KEY = ENV['BUGSNAG_API_KEY']
-	end
-
 	module Intercom
 		APP_ID = 't2bi7urt'
 	end

--- a/source/layouts/partials/_analytics_js.html.erb
+++ b/source/layouts/partials/_analytics_js.html.erb
@@ -1,17 +1,3 @@
-<% if ApplicationConfig.const_defined?(:Bugsnag) && ApplicationConfig::Bugsnag::API_KEY %>
-  <!-- Bugsnag -->
-  <script src="https://d2wy8f7a9ursnm.cloudfront.net/bugsnag-3.min.js"
-    data-apikey='<%= ApplicationConfig::Bugsnag::API_KEY %>'></script>
-
-  <script>
-    if (typeof Bugsnag !== 'undefined') {
-      Bugsnag.releaseStage = '<%= env_name %>';
-      Bugsnag.notifyReleaseStages = ["production", "staging", "testing"];
-    }
-  </script>
-  <!-- End Bugsnag -->
-<% end %>
-
 <% if ApplicationConfig.const_defined?(:GoogleAnalytics) && ApplicationConfig::GoogleAnalytics::TAG_MANAGER_CONTAINER %>
   <script> // Google Tag Manager
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
We haven't had any Bugsnags in the past 60 days so it's either that this isn't working correctly or it's not valid.  Given we don't actively maintain this and we're cleaning up Bugsnag, we should clean this up.

The Github Action which sent releases appeared to no longer be working as the last one was >2 years old.  The
`secrets.BUGSNAG_API_KEY` and the Bugsnag project itself should be deleted.