### PR TITLE
Bump rails-html-sanitizer 1.0.4 -> 1.4.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'aws-s3'
 gem 'middleman-remover'
 
 # support whitelist-sanitizing content (remove script-tags, etc.)
-gem 'rails-html-sanitizer', '~> 1.0.4' # 1.0.3 has a CVE
+gem 'rails-html-sanitizer'
 
 gem 'stopwords-filter', require: 'stopwords'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       contentful (~> 2.1)
       contentful-webhook-listener (~> 0.1)
       middleman-core (~> 3.4)
-    crass (1.0.5)
+    crass (1.0.6)
     diff-lcs (1.4.4)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
@@ -254,7 +254,7 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    loofah (2.3.1)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -346,8 +346,8 @@ GEM
     rack-rewrite (1.5.1)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
+    rails-html-sanitizer (1.4.3)
+      loofah (~> 2.3)
     rake (13.0.6)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
@@ -432,7 +432,7 @@ DEPENDENCIES
   middleman-syntax
   nokogiri (>= 1.10.8)
   rack-rewrite
-  rails-html-sanitizer (~> 1.0.4)
+  rails-html-sanitizer
   rake
   rspec
   stopwords-filter


### PR DESCRIPTION
### 📝 Description

Bump to handle [CVE-2022-32209](https://github.com/advisories/GHSA-pg8v-g4xq-hww9). (Same update as in [investapp](https://github.com/sharesight/investapp/pull/10622) and [www.sharesight.com](https://github.com/sharesight/www.sharesight.com/pull/384))

No story.