### PR TITLE
Adding url field to `contents.json.erb` that returns static-www or help link

### DIFF
--- a/helpers/middleman/collection.rb
+++ b/helpers/middleman/collection.rb
@@ -28,7 +28,7 @@ module MiddlemanCollectionHelpers
       return static_page_url(page, locale_id: locale_id)
     end
 
-    return  page_url(page, locale_id: locale_id, base_url: config[:base_url])
+    page_url(page, locale_id: locale_id, base_url: config[:base_url])
   end
 
   def category_url(category, locale_id: default_locale_id, base_url: config[:base_url])

--- a/helpers/middleman/collection.rb
+++ b/helpers/middleman/collection.rb
@@ -18,7 +18,17 @@ module MiddlemanCollectionHelpers
   end
 
   def page_path(page, locale_id: default_locale_id)
-    page_url(page, locale_id: locale_id, base_url: config[:base_url])
+    page_url(page, locale_id: locale_id, base_url: '')
+  end
+
+  # During the migration of help content over to static-www,
+  # some of the help links will now be replaced with static-www urls
+  def new_content_url(page, locale_id: default_locale_id)
+    if page[:static_url_slug]
+      return static_page_url(page, locale_id: locale_id)
+    end
+
+    return  page_url(page, locale_id: locale_id, base_url: config[:base_url])
   end
 
   def category_url(category, locale_id: default_locale_id, base_url: config[:base_url])

--- a/helpers/middleman/collection.rb
+++ b/helpers/middleman/collection.rb
@@ -11,8 +11,14 @@ module MiddlemanCollectionHelpers
     localize_url(path, locale_id: locale_id, base_url: base_url)
   end
 
+  def static_page_url(page, locale_id: default_locale_id)
+    path = page[:static_url_slug]
+
+    localize_url(path, locale_id: locale_id, base_url: config[:marketing_url])
+  end
+
   def page_path(page, locale_id: default_locale_id)
-    page_url(page, locale_id: locale_id, base_url: '')
+    page_url(page, locale_id: locale_id, base_url: config[:base_url])
   end
 
   def category_url(category, locale_id: default_locale_id, base_url: config[:base_url])

--- a/source/contents.json.erb
+++ b/source/contents.json.erb
@@ -15,8 +15,9 @@
         path:                  page_path(page, locale_id: locale_obj[:id]),
         description:           page[:meta_description],
         category_name:         page[:category][:name],
+        url:                   new_content_url(page, locale_id: locale_obj[:id]),
 
-        # reduce the amount of data downloaded in browsers – only keep the first 400 characters of contents.json
+        # reduce the amount of data downloaded in browsers – only keep the first 400 characters of contents.json
         content:               SearchHelper::condense_content(page[:content].to_s.gsub(%r{[\[\]#\*<>\/]}, ' '))[0..400],
         keywords:              page[:keywords]&.to_s
       }

--- a/source/js/search.js.es6.erb
+++ b/source/js/search.js.es6.erb
@@ -109,11 +109,12 @@
   };
 
 
-  const renderResult = ({ title, path }) => {
+  const renderResult = ({ title, url }) => {
+    console.log(url, '@@@');
     const li = document.createElement('li');
     const link = document.createElement('a');
 
-    link.href = path;
+    link.href = url;
     link.innerText = title;
 
     li.appendChild(link);
@@ -121,8 +122,9 @@
   }
 
   const appendResultToPage = (result) => {
+    console.log(result,'@@result');
     document.querySelector("#search-results").appendChild(
-      renderResult({ title: result.title, path: result.path })
+      renderResult({ title: result.title, url: result.url })
     );
   }
 

--- a/source/js/search.js.es6.erb
+++ b/source/js/search.js.es6.erb
@@ -110,7 +110,6 @@
 
 
   const renderResult = ({ title, url }) => {
-    console.log(url, '@@@');
     const li = document.createElement('li');
     const link = document.createElement('a');
 
@@ -122,7 +121,6 @@
   }
 
   const appendResultToPage = (result) => {
-    console.log(result,'@@result');
     document.querySelector("#search-results").appendChild(
       renderResult({ title: result.title, url: result.url })
     );

--- a/spec/helpers/middleman/collection_spec.rb
+++ b/spec/helpers/middleman/collection_spec.rb
@@ -42,7 +42,7 @@ describe 'Collection Middleman Helper', :type => :helper do
       get_pages().each do |_page|
         _page.static_url_slug = nil
         expect(@app.new_content_url(_page)).to be_kind_of(::String)
-        expect(@app.new_content_url(_page)).to include("http://localhost:4567/")
+        expect(@app.new_content_url(_page)).to include("http://" || 'https://')
       end
     end
 

--- a/spec/helpers/middleman/collection_spec.rb
+++ b/spec/helpers/middleman/collection_spec.rb
@@ -16,6 +16,45 @@ describe 'Collection Middleman Helper', :type => :helper do
     end
   end
 
+  # static_page_url test
+  context "static_page_url" do
+    # This is a proxy to other tested helpers.
+    it "should return a string" do
+      get_pages().each do |_page|
+        _page.static_url_slug = 'supported-stock-exchanges-managed-funds-mutual-funds'
+        expect(@app.static_page_url(_page)).to be_kind_of(::String)
+      end
+    end
+
+    it "returns expected url" do
+      get_pages().each do |_page|
+        _page.static_url_slug = 'supported-stock-exchanges-managed-funds-mutual-funds'
+        expect(@app.static_page_url(_page)).to eq("https://www.sharesight.com/supported-stock-exchanges-managed-funds-mutual-funds/")
+      end
+    end
+  end
+
+  # new_content_url test
+
+  context "new_content_url" do
+    # This is a proxy to other tested helpers.
+    it "returns full helpsite url when static_url_slug is not present" do
+      get_pages().each do |_page|
+        _page.static_url_slug = nil
+        expect(@app.new_content_url(_page)).to be_kind_of(::String)
+        expect(@app.new_content_url(_page)).to include("http://localhost:4567/")
+      end
+    end
+
+    it "returns full static url when static_url_slug present" do
+      get_pages().each do |_page|
+        _page.static_url_slug = 'supported-stock-exchanges-managed-funds-mutual-funds'
+        expect(@app.new_content_url(_page)).to be_kind_of(::String)
+        expect(@app.new_content_url(_page)).to eq("https://www.sharesight.com/supported-stock-exchanges-managed-funds-mutual-funds/")
+      end
+    end
+  end
+
   context "category_url and category_path" do
     # This is a proxy to other tested helpers.
     it "should return a string" do
@@ -97,7 +136,7 @@ describe 'Collection Middleman Helper', :type => :helper do
         locale_ids = page_locales.map{|l| l[:id]}
 
         expect(page_locales).to be_kind_of(Array)
-        expect(this_page && this_page[:id]).to eq(id), "Page not found for #{id} – has this page been deleted or is invalid?"
+        expect(this_page && this_page[:id]).to eq(id), "Page not found for #{id} – has this page been deleted or is invalid?"
         expect(locale_ids).to eq(expectation), "Locales did not match expectation for id: #{this_page[:id]}, got #{locale_ids}, expected #{expectation}"
       end
     end

--- a/spec/helpers/middleman/collection_spec.rb
+++ b/spec/helpers/middleman/collection_spec.rb
@@ -29,7 +29,7 @@ describe 'Collection Middleman Helper', :type => :helper do
     it "returns expected url" do
       get_pages().each do |_page|
         _page.static_url_slug = 'supported-stock-exchanges-managed-funds-mutual-funds'
-        expect(@app.static_page_url(_page)).to eq("https://www.sharesight.com/supported-stock-exchanges-managed-funds-mutual-funds/")
+        expect(@app.static_page_url(_page)).to include("www.sharesight.com/supported-stock-exchanges-managed-funds-mutual-funds/")
       end
     end
   end
@@ -50,7 +50,7 @@ describe 'Collection Middleman Helper', :type => :helper do
       get_pages().each do |_page|
         _page.static_url_slug = 'supported-stock-exchanges-managed-funds-mutual-funds'
         expect(@app.new_content_url(_page)).to be_kind_of(::String)
-        expect(@app.new_content_url(_page)).to eq("https://www.sharesight.com/supported-stock-exchanges-managed-funds-mutual-funds/")
+        expect(@app.new_content_url(_page)).to include("www.sharesight.com/supported-stock-exchanges-managed-funds-mutual-funds/")
       end
     end
   end

--- a/spec/helpers/middleman/collection_spec.rb
+++ b/spec/helpers/middleman/collection_spec.rb
@@ -42,7 +42,7 @@ describe 'Collection Middleman Helper', :type => :helper do
       get_pages().each do |_page|
         _page.static_url_slug = nil
         expect(@app.new_content_url(_page)).to be_kind_of(::String)
-        expect(@app.new_content_url(_page)).to include("http://" || 'https://')
+        expect(@app.new_content_url(_page)).to match(%r{https{0,1}://})
       end
     end
 


### PR DESCRIPTION
For context:
- 

- This is part of the work towards the help site migration.
- So that when users search for articles in the help site, we can easily redirect the users to the new page the content now lives on - in static-www

✅ In this PR: 
-


- Added an extra `url` field to the objects in `contents.json` which will contain full length paths e.g. 'https://help.sharesight.com/au/drp' or 'https://www.sharesight.com/supported-stock-exchanges-managed-funds-mutual-funds/'
- Added some functions that will return the full help site link or full static-www link depending on if `static_url_slug` is present
- Updating the search functions to return full urls - either static site urls or help site urls

**In addition to this PR, a contentful change will be required:** 
- adding a field static_url_slug which will contain the new location of the help content in static-www 

🖊️ To Do: 
- 

- [ ] Add tests for new functions
- [x] Add static_url_slug field to content model in contentful
- [x] Populate the static_url_slug field for https://help.sharesight.com/supported-stock-exchanges-and-managed-funds/ to the new supported markets page `supported-stock-exchanges-managed-funds-mutual-funds`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204510991860925