### PR TITLE
Updating sharesight pro labelling to sharesight business in footer

### DIFF
--- a/source/partials/_footer.html.erb
+++ b/source/partials/_footer.html.erb
@@ -20,7 +20,7 @@
 
     # This has an empty label—no header, but still space
     'Partners' => [
-      { name: 'Sharesight Pro', marketing_page: 'pro', title: "Sharesight Pro" },
+      { name: 'Sharesight Business', marketing_page: 'business', title: "Sharesight Business" },
       { name: 'Partner Directory', marketing_page: 'partners', title: "Partner Directory | #{locale_obj[:append_title]}" },
       { name: 'Become a Partner', marketing_page: 'become-a-partner', title: "Partner with Sharesight | #{locale_obj[:append_title]}" },
       { name: 'Become an Affiliate', marketing_page: 'affiliates', title: "Become an Affiliate | #{locale_obj[:append_title]}" },
@@ -35,7 +35,7 @@
       { name: 'Webinars & Events', marketing_page: 'events', title: "Webinars & Events | #{locale_obj[:append_title]}" },
       { name: 'Privacy Policy', marketing_page: 'privacy-policy', title: "Privacy Policy | #{locale_obj[:append_title]}" },
       { name: 'Terms of Use', marketing_page: 'sharesight-terms-of-use', title: "Terms of Use | #{locale_obj[:append_title]}" },
-      { name: 'Pro Terms of Use', marketing_page: 'sharesight-professional-terms-of-use', title: "Terms of Service | Sharesight Pro" },
+      { name: 'Business Terms of Use', marketing_page: 'sharesight-professional-terms-of-use', title: "Terms of Service | Sharesight Business" },
     ]
   }
 %>

--- a/spec/features/footer_spec.rb
+++ b/spec/features/footer_spec.rb
@@ -17,7 +17,7 @@ describe 'Footer', type: :feature do
       ["Reviews", base_url("/reviews/", base_url: Capybara.app.config[:marketing_url])],
 
       # Partners:
-      ["Sharesight Pro", base_url("/pro/", base_url: Capybara.app.config[:marketing_url])],
+      ["Sharesight Business", base_url("/business/", base_url: Capybara.app.config[:marketing_url])],
       ["Partner Directory", base_url("/partners/", base_url: Capybara.app.config[:marketing_url])],
       ["Become a Partner", base_url("/become-a-partner/", base_url: Capybara.app.config[:marketing_url])],
       ["Become an Affiliate", base_url("/affiliates/", base_url: Capybara.app.config[:marketing_url])],
@@ -31,7 +31,7 @@ describe 'Footer', type: :feature do
       ["Webinars & Events", base_url("/events/", base_url: Capybara.app.config[:marketing_url])],
       ["Privacy Policy", base_url("/privacy-policy/", base_url: Capybara.app.config[:marketing_url])],
       ["Terms of Use", base_url("/sharesight-terms-of-use/", base_url: Capybara.app.config[:marketing_url])],
-      ["Pro Terms of Use", base_url("/sharesight-professional-terms-of-use/", base_url: Capybara.app.config[:marketing_url])],
+      ["Business Terms of Use", base_url("/sharesight-professional-terms-of-use/", base_url: Capybara.app.config[:marketing_url])],
 
       # locales:
       ["Global", base_url('/')],


### PR DESCRIPTION
## ✅ In this PR: 

- Update `Sharesight Pro` label to `Sharesight Business` and `Pro Terms of Use` to `Business Terms of Use` in the footer


## 📓 References: 

- [Asana](https://app.asana.com/0/1202529446124670/1209779457750930)