### PR TITLE
fix: Permissions for Build and Push to S3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,6 @@ env:
   # calculated values (for steps.env.outputs.*)
   APP_ENV: ${{ (github.event_name == 'deployment' && github.event.deployment.environment) || (github.ref == 'refs/heads/master' && 'production') || 'staging' }}
   SHOULD_DEPLOY: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && 'true' || 'false' }}
-
-  # for deploy
-  AWS_DEPLOY_ACCESS_ID: ${{ secrets.AWS_DEPLOY_ACCESS_ID }}
-  AWS_DEPLOY_SECRET_KEY: ${{ secrets.AWS_DEPLOY_SECRET_KEY }}
-
   # build, test, and deploy
   CONTENTFUL_MASTER_TOKEN: ${{ secrets.CONTENTFUL_MASTER_TOKEN }}
   CONTENTFUL_PREVIEW_TOKEN: ${{ secrets.CONTENTFUL_PREVIEW_TOKEN }}
@@ -57,6 +52,12 @@ jobs:
       with:
         bundler-cache: true
 
+    - name: AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::104220322948:role/github-actions-static-sites-help-deploy
+        aws-region: us-east-1
+
     # -------- JS & Dependencies
     - name: Install Node
       uses: actions/setup-node@v3
@@ -86,7 +87,7 @@ jobs:
       with:
         state: 'pending'
         token: ${{ secrets.GITHUB_TOKEN }}
-   
+
     - name: Deploy to S3
       if: success() && steps.env.outputs.should_deploy == 'true'
       run: bundle exec middleman s3_sync

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,11 @@ env:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      id-token: write
+      # This is required for the aws-actions/configure-aws-credentials@v4 action to assume a role.
+      # See
     runs-on: ubuntu-latest
 
     steps:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,8 +15,8 @@ module ApplicationConfig
 
   module S3
     BUCKET = 'sharesight-help'
-    ACCESS_ID = ENV['AWS_DEPLOY_ACCESS_ID']
-    SECRET_KEY = ENV['AWS_DEPLOY_SECRET_KEY']
+		ACCESS_ID = ENV['AWS_ACCESS_KEY_ID']
+		SECRET_KEY = ENV['AWS_SECRET_ACCESS_KEY']
     CLOUDFRONT_DIST_ID = 'E1BFZMZ0P2YA59'
   end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -15,8 +15,8 @@ module ApplicationConfig
 
 	module S3
 		BUCKET = 'sharesight-help-staging'
-		ACCESS_ID = ENV['AWS_DEPLOY_ACCESS_ID']
-		SECRET_KEY = ENV['AWS_DEPLOY_SECRET_KEY']
+		ACCESS_ID = ENV['AWS_ACCESS_KEY_ID']
+		SECRET_KEY = ENV['AWS_SECRET_ACCESS_KEY']
 		CLOUDFRONT_DIST_ID = 'EXA3OX5JP2617'
 	end
 end

--- a/config/initializers/uri.rb
+++ b/config/initializers/uri.rb
@@ -1,0 +1,5 @@
+module URI
+  def self.escape url
+    URI::Parser.new.escape url
+  end
+end


### PR DESCRIPTION
# Description
Recently due to SOC2 compliance, some IAM Users were detected with long lived credentials and deleted. One of the users was help_deploy, which was used to deploy the help site. This PR introduces a safer STS token based authentication method which uses a temporary auth token to push new files to S3.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210553776358858