### PR TITLE
Introduce monkey-patch to circumvent deprecation warnings

### DIFF
--- a/config/contentful.rb
+++ b/config/contentful.rb
@@ -20,3 +20,11 @@ module ContentfulConfig
 		]
 	end
 end
+
+# monkey-patch to get around this warning with Ruby 2.7
+#   lib/middleman-core/util.rb:71: warning: URI.unescape is obsolete
+module URI
+  def self.unescape(string)
+    CGI.escape(string)
+  end
+end

--- a/config/initializers/uri.rb
+++ b/config/initializers/uri.rb
@@ -1,5 +1,0 @@
-module URI
-  def self.escape url
-    URI::Parser.new.escape url
-  end
-end


### PR DESCRIPTION
for `URI.un…escape` snd get around this warning with Ruby 2.7:

```
lib/middleman-core/util.rb:71: warning: URI.unescape is obsolete
```