### PR TITLE
fix: Add Session Token for S3 Sync command

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -103,6 +103,7 @@ if ApplicationConfig.const_defined?(:S3) && ['staging', 'production'].include?(e
     s3_sync.region                     = 'us-east-1'     # The AWS region for your bucket.
     s3_sync.aws_access_key_id          = ApplicationConfig::S3::ACCESS_ID
     s3_sync.aws_secret_access_key      = ApplicationConfig::S3::SECRET_KEY
+    s3_sync.aws_session_token          = ApplicationConfig::S3::SESSION_TOKEN
 
     s3_sync.delete                     = true # This deletes files that are not built, rather than strictly appending new files.
     s3_sync.after_build                = false # WARNING: NEVER SET TO TRUE!  This breaks the plugin entirely.

--- a/config.rb
+++ b/config.rb
@@ -101,9 +101,6 @@ if ApplicationConfig.const_defined?(:S3) && ['staging', 'production'].include?(e
   activate :s3_sync do |s3_sync|
     s3_sync.bucket                     = ApplicationConfig::S3::BUCKET # The name of the S3 bucket you are targeting. This is globally unique.
     s3_sync.region                     = 'us-east-1'     # The AWS region for your bucket.
-    s3_sync.aws_access_key_id          = ApplicationConfig::S3::ACCESS_ID
-    s3_sync.aws_secret_access_key      = ApplicationConfig::S3::SECRET_KEY
-    s3_sync.aws_session_token          = ApplicationConfig::S3::SESSION_TOKEN
 
     s3_sync.delete                     = true # This deletes files that are not built, rather than strictly appending new files.
     s3_sync.after_build                = false # WARNING: NEVER SET TO TRUE!  This breaks the plugin entirely.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,6 +17,7 @@ module ApplicationConfig
     BUCKET = 'sharesight-help'
 		ACCESS_ID = ENV['AWS_ACCESS_KEY_ID']
 		SECRET_KEY = ENV['AWS_SECRET_ACCESS_KEY']
+		SESSION_TOKEN = ENV['AWS_SESSION_TOKEN']
     CLOUDFRONT_DIST_ID = 'E1BFZMZ0P2YA59'
   end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -17,6 +17,7 @@ module ApplicationConfig
 		BUCKET = 'sharesight-help-staging'
 		ACCESS_ID = ENV['AWS_ACCESS_KEY_ID']
 		SECRET_KEY = ENV['AWS_SECRET_ACCESS_KEY']
+		SESSION_TOKEN = ENV['AWS_SESSION_TOKEN']
 		CLOUDFRONT_DIST_ID = 'EXA3OX5JP2617'
 	end
 end


### PR DESCRIPTION
Getting a 403 forbidden error on s3_sync. This adds the session token that is missing from the authorization.